### PR TITLE
Add <noscript> to index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -46,6 +46,8 @@
 </head>
 <body>
   <app-root></app-root>
+  
+  <noscript>Please enable JavaScript to continue using this application.</noscript>
 
   <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_API_KEY}}&amp;libraries=places,geometry"></script>
 


### PR DESCRIPTION
Lighthouse: `Does not provide fallback content when JavaScript is not available`

Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app.